### PR TITLE
Updates path-complete-extname

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "app-module-path": "1.1.0",
     "clean-css": "^3.4.18",
     "html-minifier": "3.0.3",
-    "path-complete-extname": "0.1.0",
+    "path-complete-extname": "^1.0.0",
     "uglify-js": "^2.7.0",
     "when": "^3.7.5"
   },


### PR DESCRIPTION
Hi @davej, I just recently released [paht-complete-extname@1.0.0](https://github.com/ruyadorno/path-complete-extname) in order to mitigate a vulnerability report that traces back to the original **node@0.10** implementation in which the module was based on.

The solution was to rewrite the module basing it in the [current node implementation](https://github.com/nodejs/node/tree/v9.6.1/lib/path.js) and publish a new major version. I'm reaching out to all libraries described on [npm dependencies list](https://www.npmjs.com/browse/depended/path-complete-extname) to make sure they can all get the new patched version as soon as possible.

I decided for a major release in order to be able to properly follow [semver](https://semver.org/) from now on and to properly reflect the stable state of the library that has been around for 4 years 😊 

Let me know if there are any concerns and please feel free to [review all the code changes](https://github.com/ruyadorno/path-complete-extname/pull/1/files).

Best,

Ruy Adorno